### PR TITLE
Clothing tab in sfinv should be right to the creative

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,5 +1,6 @@
 multiskin?
 sfinv?
+creative?
 inventory_plus?
 unified_inventory?
 wool?


### PR DESCRIPTION
If I start minetest game with clothing mod in creative, the sfinv tab order is Crafting, Clothing, All, Nodes, Tools, Items, Skins, Armor..
The Clothing in second place feels wrong for me, the creative tabs All, Nodes, Tools, Items should be before.
Using this optional dependency the new order is as expected: Crafting, All, Nodes, Tools, Items, Clothing, Skins, Armor..