### PR TITLE
Made the loom craftable from any wood

### DIFF
--- a/loom.lua
+++ b/loom.lua
@@ -120,8 +120,8 @@ minetest.register_node("clothing:loom", {
 minetest.register_craft({
 	output = 'clothing:loom',
 	recipe = {
-		{'group:stick', 'default:pinewood', 'group:stick'},
-		{'group:stick', 'default:pinewood', 'group:stick'},
-		{'default:pinewood', "default:pinewood", 'default:pinewood'},
+		{'group:stick', 'group:wood', 'group:stick'},
+		{'group:stick', 'group:wood', 'group:stick'},
+		{'group:wood', "group:wood", 'group:wood'},
 	},
 })


### PR DESCRIPTION
I made the supposition the loom is supposed to be craftable from any wood than just pinewood, which is not available on some maps (mapgen 6 notably, if I am not mistaken)